### PR TITLE
fix(leases): use daysAhead for upcoming renewals

### DIFF
--- a/src/lib/api/clients/leases.ts
+++ b/src/lib/api/clients/leases.ts
@@ -75,7 +75,8 @@ export const leasesApi = {
   },
 
   async getUpcomingRenewals(daysAhead = 90): Promise<Array<Lease & { daysUntilExpiry: number }>> {
-    const res = await apiGet(`/lease-renewals/upcoming?days=${daysAhead}`);
+    // Edge + Express both accept daysAhead (not `days`).
+    const res = await apiGet(`/lease-renewals/upcoming?daysAhead=${daysAhead}`);
     return ((res as { data: Array<Lease & { daysUntilExpiry: number }> }).data ?? []);
   },
 };


### PR DESCRIPTION
## Summary
- Use `daysAhead` query param for upcoming lease renewals so the dashboard matches the API contract.

## Test plan
- [ ] Open upcoming renewals and confirm results respect the daysAhead window
- [ ] Confirm no regressions in lease list/renewal views


Made with [Cursor](https://cursor.com)